### PR TITLE
Use in memory database rather than file

### DIFF
--- a/src/tests/b00000.vtc
+++ b/src/tests/b00000.vtc
@@ -35,7 +35,7 @@ varnish v1 -vcl+backend {
 	import sqlite3 from "${vmod_topbuild}/src/.libs/libvmod_sqlite3.so";
 
 	sub vcl_init {
-		sqlite3.open("mydata.db", "|;");
+		sqlite3.open(":memory:", "|;");
 	}
 
 	sub vcl_recv {


### PR DESCRIPTION
This makes testing easier since you don't need to worry about permissions, re-running tests, etc.